### PR TITLE
UMN customized survey.db, sqlite3 installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ FROM jupyter/datascience-notebook
 
 MAINTAINER David Naughton <naughton@umn.edu>
 
+USER root
+RUN apt-get update && \
+    apt-get install sqlite3
+
 USER $NB_UID
 RUN mkdir "/home/${NB_USER}/Desktop" && \
     cd "/home/${NB_USER}/Desktop" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ MAINTAINER David Naughton <naughton@umn.edu>
 USER $NB_UID
 RUN mkdir "/home/${NB_USER}/Desktop" && \
     cd "/home/${NB_USER}/Desktop" && \
-    wget https://swcarpentry.github.io/sql-novice-survey/files/survey.db && \
+    wget https://umn-dash.github.io/sql-novice-survey/files/survey.db && \
     chmod -R g+rw "/home/${NB_USER}/Desktop" && \
     echo "PS1='\$ '" >> ~/.bashrc


### PR DESCRIPTION
- Use the UMN customized version of `survey.db`
- Install `sqlite3` in `Dockerfile`, the app was no longer available out of the base image